### PR TITLE
docs(guide/directive): delete redundant 'the'

### DIFF
--- a/docs/content/guide/directive.ngdoc
+++ b/docs/content/guide/directive.ngdoc
@@ -123,7 +123,7 @@ The other forms shown above are accepted for legacy reasons but we advise you to
 `$compile` can match directives based on element names (E), attributes (A), class names (C),
 and comments (M).
 
-The built-in the AngularJS directives show in their documentation page which type of matching they support.
+The built-in AngularJS directives show in their documentation page which type of matching they support.
 
 The following demonstrates the various ways a directive (`myDir` in this case) that matches all
 4 types can be referenced from within a template.


### PR DESCRIPTION
Closes #15891

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

