### PR TITLE
refactor($parse): do not pass scope,locals to interceptor fns

### DIFF
--- a/src/ng/parse.js
+++ b/src/ng/parse.js
@@ -1940,12 +1940,12 @@ function $ParseProvider() {
 
       function regularInterceptedExpression(scope, locals, assign, inputs) {
         var value = useInputs && inputs ? inputs[0] : parsedExpression(scope, locals, assign, inputs);
-        return interceptorFn(value, scope, locals);
+        return interceptorFn(value);
       }
 
       function oneTimeInterceptedExpression(scope, locals, assign, inputs) {
         var value = useInputs && inputs ? inputs[0] : parsedExpression(scope, locals, assign, inputs);
-        var result = interceptorFn(value, scope, locals);
+        var result = interceptorFn(value);
         // we only return the interceptor's result if the
         // initial value is defined (for bind-once)
         return isDone(value) ? result : value;

--- a/test/ng/parseSpec.js
+++ b/test/ng/parseSpec.js
@@ -3232,6 +3232,74 @@ describe('parser', function() {
         });
 
         describe('interceptorFns', function() {
+          it('should only be passed the intercepted value', inject(function($parse) {
+            var args;
+            function interceptor(v) {
+              args = sliceArgs(arguments);
+              return v;
+            }
+
+            scope.$watch($parse('a', interceptor));
+
+            scope.a = 1;
+            scope.$digest();
+            expect(args).toEqual([1]);
+          }));
+
+          it('should only be passed the intercepted value when double-intercepted',
+              inject(function($parse) {
+            var args1;
+            function int1(v) {
+              args1 = sliceArgs(arguments);
+              return v + 2;
+            }
+            var args2;
+            function int2(v) {
+              args2 = sliceArgs(arguments);
+              return v + 4;
+            }
+
+            scope.$watch($parse($parse('a', int1), int2));
+
+            scope.a = 1;
+            scope.$digest();
+            expect(args1).toEqual([1]);
+            expect(args2).toEqual([3]);
+          }));
+
+          it('should support locals', inject(function($parse) {
+            var args;
+            function interceptor(v) {
+              args = sliceArgs(arguments);
+              return v + 4;
+            }
+
+            var exp = $parse('a + b', interceptor);
+            scope.a = 1;
+
+            expect(exp(scope, {b: 2})).toBe(7);
+            expect(args).toEqual([3]);
+          }));
+
+          it('should support locals when double-intercepted', inject(function($parse) {
+            var args1;
+            function int1(v) {
+              args1 = sliceArgs(arguments);
+              return v + 4;
+            }
+            var args2;
+            function int2(v) {
+              args2 = sliceArgs(arguments);
+              return v + 8;
+            }
+
+            var exp = $parse($parse('a + b', int1), int2);
+
+            scope.a = 1;
+            expect(exp(scope, {b: 2})).toBe(15);
+            expect(args1).toEqual([3]);
+            expect(args2).toEqual([7]);
+          }));
 
           it('should always be invoked if they are flagged as having $stateful',
               inject(function($parse) {


### PR DESCRIPTION
All internal use of interceptors are for things such as data
conversion/normalizing, never reading state from the scope/locals.
This is the intended use and makes interceptors more like filters
(which receive only the input value + args, no scope/locals).

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

