### PR TITLE
fix($httpParamSerializerJQLike): call functions as jQuery does

### DIFF
--- a/src/ng/http.js
+++ b/src/ng/http.js
@@ -122,6 +122,9 @@ function $HttpParamSerializerJQLikeProvider() {
                 (topLevel ? '' : ']'));
           });
         } else {
+          if (isFunction(toSerialize)) {
+            toSerialize = toSerialize();
+          }
           parts.push(encodeUriQuery(prefix) + '=' +
               (toSerialize == null ? '' : encodeUriQuery(serializeValue(toSerialize))));
         }

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -2364,15 +2364,39 @@ describe('$http param serializers', function() {
       expect(decodeURIComponent(jqrSer({a: 'b', foo: ['bar', 'baz']}))).toEqual('a=b&foo[]=bar&foo[]=baz');
     });
 
+    it('should serialize arrays with functions', function() {
+      expect(jqrSer({foo: [valueFn('bar')]})).toEqual('foo%5B%5D=bar'); // foo[]=bar
+    });
+
+    it('should serialize arrays with functions inside objects', function() {
+      expect(jqrSer({foo: {bar: [valueFn('baz')]}})).toEqual('foo%5Bbar%5D%5B%5D=baz'); // foo[bar][]=baz
+    });
+
     it('should serialize objects by repeating param name with [key] suffix', function() {
       expect(jqrSer({a: 'b', foo: {'bar': 'barv', 'baz': 'bazv'}})).toEqual('a=b&foo%5Bbar%5D=barv&foo%5Bbaz%5D=bazv');
                                                                            //a=b&foo[bar]=barv&foo[baz]=bazv
+    });
+
+    it('should serialize objects with function properties', function() {
+      expect(jqrSer({a: valueFn('b')})).toEqual('a=b');
+    });
+
+    it('should serialize objects with function properties returning an object', function() {
+      expect(jqrSer({a: valueFn({b: 'c'})})).toEqual('a=%7B%22b%22:%22c%22%7D'); //a={"b":"c"}
     });
 
     it('should serialize nested objects by repeating param name with [key] suffix', function() {
       expect(jqrSer({a: ['b', {c: 'd'}], e: {f: 'g', 'h': ['i', 'j']}})).toEqual(
          'a%5B%5D=b&a%5B1%5D%5Bc%5D=d&e%5Bf%5D=g&e%5Bh%5D%5B%5D=i&e%5Bh%5D%5B%5D=j');
          //a[]=b&a[1][c]=d&e[f]=g&e[h][]=i&e[h][]=j
+    });
+
+    it('should serialize nested objects with function properties', function() {
+      expect(jqrSer({foo: {bar: valueFn('barv')}})).toEqual('foo%5Bbar%5D=barv'); //foo[bar]=barv
+    });
+
+    it('should serialize nested objects with function properties returning an object', function() {
+      expect(jqrSer({foo: {bar: valueFn({bav: 'barv'})}})).toEqual('foo%5Bbar%5D=%7B%22bav%22:%22barv%22%7D'); //foo[bar]={"bav":"barv"}
     });
 
     it('should serialize objects inside array elements using their index', function() {


### PR DESCRIPTION
Previously, `httpParamSerializerJQLike` stringified function properties without executing them.
This commit ensures function properties are executed and the return value is used.

Fixes #16138

Closes #16139

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

