### PR TITLE
Update upstream

### DIFF
--- a/src/auto/injector.js
+++ b/src/auto/injector.js
@@ -70,12 +70,8 @@ var FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
 var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 
-function stringifyFn(fn) {
-  return Function.prototype.toString.call(fn);
-}
-
 function extractArgs(fn) {
-  var fnText = stringifyFn(fn).replace(STRIP_COMMENTS, ''),
+  var fnText = Function.prototype.toString.call(fn).replace(STRIP_COMMENTS, ''),
       args = fnText.match(ARROW_ARG) || fnText.match(FN_ARGS);
   return args;
 }
@@ -914,19 +910,6 @@ function createInjector(modulesToLoad, strictDi) {
       return args;
     }
 
-    function isClass(func) {
-      // Support: IE 9-11 only
-      // IE 9-11 do not support classes and IE9 leaks with the code below.
-      if (msie || typeof func !== 'function') {
-        return false;
-      }
-      var result = func.$$ngIsClass;
-      if (!isBoolean(result)) {
-        result = func.$$ngIsClass = /^class\b/.test(stringifyFn(func));
-      }
-      return result;
-    }
-
     function invoke(fn, self, locals, serviceName) {
       if (typeof locals === 'string') {
         serviceName = locals;
@@ -938,14 +921,9 @@ function createInjector(modulesToLoad, strictDi) {
         fn = fn[fn.length - 1];
       }
 
-      if (!isClass(fn)) {
-        // http://jsperf.com/angularjs-invoke-apply-vs-switch
-        // #5388
-        return fn.apply(self, args);
-      } else {
-        args.unshift(null);
-        return new (Function.prototype.bind.apply(fn, args))();
-      }
+      // http://jsperf.com/angularjs-invoke-apply-vs-switch
+      // #5388
+      return fn.apply(self, args);
     }
 
 

--- a/src/ng/controller.js
+++ b/src/ng/controller.js
@@ -81,16 +81,11 @@ function $ControllerProvider() {
      * It's just a simple call to {@link auto.$injector $injector}, but extracted into
      * a service, so that one can override this service with [BC version](https://gist.github.com/1649788).
      */
-    return function $controller(expression, locals, later, ident) {
+    return function $controller(expression, locals, ident) {
       // PRIVATE API:
-      //   param `later` --- indicates that the controller's constructor is invoked at a later time.
-      //                     If true, $controller will allocate the object with the correct
-      //                     prototype chain, but will not invoke the controller until a returned
-      //                     callback is invoked.
       //   param `ident` --- An optional label which overrides the label parsed from the controller
       //                     expression, if any.
       var instance, match, constructor, identifier;
-      later = later === true;
       if (ident && isString(ident)) {
         identifier = ident;
       }
@@ -114,41 +109,6 @@ function $ControllerProvider() {
         }
 
         assertArgFn(expression, constructor, true);
-      }
-
-      if (later) {
-        // Instantiate controller later:
-        // This machinery is used to create an instance of the object before calling the
-        // controller's constructor itself.
-        //
-        // This allows properties to be added to the controller before the constructor is
-        // invoked. Primarily, this is used for isolate scope bindings in $compile.
-        //
-        // This feature is not intended for use by applications, and is thus not documented
-        // publicly.
-        // Object creation: http://jsperf.com/create-constructor/2
-        var controllerPrototype = (isArray(expression) ?
-          expression[expression.length - 1] : expression).prototype;
-        instance = Object.create(controllerPrototype || null);
-
-        if (identifier) {
-          addIdentifier(locals, identifier, instance, constructor || expression.name);
-        }
-
-        return extend(function $controllerInit() {
-          var result = $injector.invoke(expression, instance, locals, constructor);
-          if (result !== instance && (isObject(result) || isFunction(result))) {
-            instance = result;
-            if (identifier) {
-              // If result changed, re-assign controllerAs value to scope.
-              addIdentifier(locals, identifier, instance, constructor || expression.name);
-            }
-          }
-          return instance;
-        }, {
-          instance: instance,
-          identifier: identifier
-        });
       }
 
       instance = $injector.instantiate(expression, locals, constructor);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -2332,14 +2332,11 @@ angular.mock.$RootElementProvider = function() {
  */
 function createControllerDecorator() {
   angular.mock.$ControllerDecorator = ['$delegate', function($delegate) {
-    return function(expression, locals, later, ident) {
-      if (later && typeof later === 'object') {
-        var instantiate = $delegate(expression, locals, true, ident);
-        var instance = instantiate();
-        angular.extend(instance, later);
-        return instance;
-      }
-      return $delegate(expression, locals, later, ident);
+    return function(expression, locals, bindings, ident) {
+      if (angular.isString(bindings)) ident = bindings;
+      var instance = $delegate(expression, locals, ident);
+      angular.extend(instance, bindings);
+      return instance;
     };
   }];
 

--- a/test/auto/injectorSpec.js
+++ b/test/auto/injectorSpec.js
@@ -482,25 +482,6 @@ describe('injector', function() {
           expect(instance).toEqual(new Clazz('a-value'));
           expect(instance.aVal()).toEqual('a-value');
         });
-
-        they('should detect ES6 classes regardless of whitespace/comments ($prop)', [
-          'class Test {}',
-          'class Test{}',
-          'class //<--ES6 stuff\nTest {}',
-          'class//<--ES6 stuff\nTest {}',
-          'class {}',
-          'class{}',
-          'class //<--ES6 stuff\n {}',
-          'class//<--ES6 stuff\n {}',
-          'class/* Test */{}',
-          'class /* Test */ {}'
-        ], function(classDefinition) {
-          // eslint-disable-next-line no-eval
-          var Clazz = eval('(' + classDefinition + ')');
-          var instance = injector.invoke(Clazz);
-
-          expect(instance).toEqual(jasmine.any(Clazz));
-        });
       }
     });
 


### PR DESCRIPTION
Now that we don't need to support `preAssignBindingsEnabled` (removed in #15782),
complexity introduced in `$controller` by #7645 can be removed.

One difference with the previous implementation is that all non-ES2015-class controller instances
were available on the element before calling their constructors. Now it depends on the relative
order of controllers. Controller constructors shouldn't be used to access other controllers
(e.g. via `$element.controller(directiveName)`). The recommended way is to use the `require`
property of the directive definition object and the life cycle hooks `$onChanges` or `$onInit`.

See
https://docs.angularjs.org/api/ng/service/$compile#-require-
https://docs.angularjs.org/api/ng/service/$compile#life-cycle-hooks

Closes #16580

<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

